### PR TITLE
Update old references to AGPL

### DIFF
--- a/hiscore/engine.py
+++ b/hiscore/engine.py
@@ -4,7 +4,7 @@ hiscore.engine
 Core methods for creating and calculating scoring functions.
 
 :copyright: (c) 2014 by Abraham Othman.
-:license: AGPL, see LICENSE for details.
+:license: BSD, see LICENSE for details.
 """
 import numpy as np
 import cvxpy as cvx

--- a/hiscore/errors.py
+++ b/hiscore/errors.py
@@ -4,7 +4,7 @@ hiscore.errors
 Errors that can arise from creating scores.
 
 :copyright: (c) 2014 by Abraham Othman.
-:license: AGPL, see LICENSE for details.
+:license: BSD, see LICENSE for details.
 """
 import numpy as np
 


### PR DESCRIPTION
Noticed the source files and LICENSE file are in conflict: presumably the intent was to switch to BSD everywhere, as a recent commit describes.
